### PR TITLE
NUMCPUS: remove upper limit of 8

### DIFF
--- a/unix/crossplatform-functions.sh
+++ b/unix/crossplatform-functions.sh
@@ -1004,8 +1004,6 @@ autodetect_cpus() {
     NUMCPUS=$(( NUMCPUS + 0 ))
     if [ "${NUMCPUS}" -lt 1 ]; then
         NUMCPUS=1
-    elif [ "${NUMCPUS}" -gt 8 ]; then
-        NUMCPUS=8
     fi
     export NUMCPUS
 }


### PR DESCRIPTION
At least on Linux there doesn't need to be an upper bound, e.g. I have 24 CPUs, and it is possible to buy machines with hundreds of cores.

(even though currently a parallel build only achieves a ~3x speedup with -j there is no need to artificially limit the number of CPUs.)

I couldn't find a reason in the git history on why the limit of 8 was introduced. 
If some OS actually needs such an upper limit then the limit could be changed to be OS specific.

Draft PR because I haven't tested this yet (would need to pin this in dkml-base-compiler to test it first)